### PR TITLE
Add Plaid public token storage API

### DIFF
--- a/app/api/store-public-token/route.ts
+++ b/app/api/store-public-token/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+
+export async function POST(req: NextRequest) {
+  try {
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const supabaseUrl = process.env.SUPABASE_URL!;
+    const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+
+    const supabase = createClient(supabaseUrl, serviceRole, {
+      global: { headers: { Authorization: authHeader } },
+    });
+
+    const { data: { user }, error: userError } = await supabase.auth.getUser();
+    if (userError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { public_token, institution } = await req.json();
+    if (!public_token) {
+      return NextResponse.json({ error: "public_token required" }, { status: 400 });
+    }
+
+    const { error } = await supabase
+      .from("public_tokens")
+      .insert({ user_id: user.id, public_token, institution });
+
+    if (error) {
+      console.error("Error storing public token", error);
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("Unexpected error storing public token", err);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}

--- a/components/ConnectBank.tsx
+++ b/components/ConnectBank.tsx
@@ -106,6 +106,7 @@ export default function ConnectBank() {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          Authorization: session ? `Bearer ${session.access_token}` : "",
         },
         body: JSON.stringify({
           public_token,


### PR DESCRIPTION
## Summary
- add Next.js API route to persist Plaid `public_token` to `public_tokens` table
- update `ConnectBank.tsx` to send auth header when storing the token

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8dc69ddc832a96696510a172eeb6