### PR TITLE
Fix repeated Plaid link script injection

### DIFF
--- a/components/ConnectBank.tsx
+++ b/components/ConnectBank.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { usePlaidLink } from "react-plaid-link";
 import { useSession, useSupabaseClient } from "@supabase/auth-helpers-react";
 
@@ -8,12 +8,15 @@ export default function ConnectBank() {
   const [linkToken, setLinkToken] = useState<string | null>(null);
   const session = useSession();
   const supabase = useSupabaseClient();
+  const fetchedRef = useRef(false);
 
-  // Fetch the link token once a session with an access token is available
+  // Fetch the link token once when a valid session is available
   useEffect(() => {
-    if (!session?.access_token || linkToken) {
+    if (!session?.access_token || fetchedRef.current || linkToken) {
       return;
     }
+
+    fetchedRef.current = true;
 
     const fetchLinkToken = async () => {
 
@@ -43,7 +46,7 @@ export default function ConnectBank() {
     };
 
     fetchLinkToken();
-  }, [session]);
+  }, [session, linkToken]);
 
   interface PlaidConfig {
     token: string;
@@ -67,50 +70,62 @@ export default function ConnectBank() {
     }>;
   }
 
-  const config: PlaidConfig = useMemo(
-    () => ({
-      token: linkToken ?? "",
-      onSuccess: async (
-        public_token: string,
-        metadata: PlaidMetadata
-      ) => {
-        const user_id = session?.user?.id;
+  function PlaidLinkButton({ token }: { token: string }) {
+    const config: PlaidConfig = useMemo(
+      () => ({
+        token,
+        onSuccess: async (
+          public_token: string,
+          metadata: PlaidMetadata
+        ) => {
+          const user_id = session?.user?.id;
 
-        // Debug logs before fetch
-        console.log("🌍 Environment:", process.env.NODE_ENV);
-        console.log("🔗 Calling store-public-token with payload:", {
-          public_token,
-          institution: metadata.institution?.name,
-          user_id,
-        });
-
-        const response = await fetch("/api/store-public-token", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: session ? `Bearer ${session.access_token}` : "",
-          },
-          body: JSON.stringify({
+          console.log("🌍 Environment:", process.env.NODE_ENV);
+          console.log("🔗 Calling store-public-token with payload:", {
             public_token,
             institution: metadata.institution?.name,
             user_id,
-          }),
-        });
+          });
 
-        if (response.ok) {
-          console.log("🔐 Public token stored successfully");
-        } else {
-          const errorData = await response.json();
-          console.error("❌ Failed to store public token", errorData);
-        }
-      },
-    }),
-    [linkToken, session]
-  );
+          const response = await fetch("/api/store-public-token", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: session ? `Bearer ${session.access_token}` : "",
+            },
+            body: JSON.stringify({
+              public_token,
+              institution: metadata.institution?.name,
+              user_id,
+            }),
+          });
 
-  const plaid = usePlaidLink(config);
+          if (response.ok) {
+            console.log("🔐 Public token stored successfully");
+          } else {
+            const errorData = await response.json();
+            console.error("❌ Failed to store public token", errorData);
+          }
+        },
+      }),
+      [token, session]
+    );
 
-  console.log("🔍 Debug:", { linkToken, plaidReady: plaid.ready });
+    const plaid = usePlaidLink(config);
+
+    console.log("🔍 Debug:", { linkToken: token, plaidReady: plaid.ready });
+
+    return (
+      <button
+        className="px-4 py-2 bg-indigo-600 text-white rounded disabled:opacity-50"
+        onClick={() => plaid.open()}
+        disabled={!plaid.ready}
+      >
+        Connect Bank Account
+      </button>
+    );
+  }
+
   return (
     <>
       <pre className="text-xs bg-gray-100 text-black p-2 mb-4 rounded">
@@ -118,13 +133,7 @@ export default function ConnectBank() {
           ? `✅ Link Token Ready:\n${linkToken}`
           : "⏳ Waiting for Link Token..."}
       </pre>
-      <button
-        className="px-4 py-2 bg-indigo-600 text-white rounded disabled:opacity-50"
-        onClick={() => plaid.open()}
-        disabled={!linkToken || !plaid.ready}
-      >
-        Connect Bank Account
-      </button>
+      {linkToken && <PlaidLinkButton token={linkToken} />}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- guard link token fetch with `useRef` so it only runs once
- render Plaid Link button only after token is available

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter` due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_683f9386a31c832aa938f4bc613251e8