### PR TITLE
Fix Plaid link token retrieval

### DIFF
--- a/app/api/create-link-token/route.ts
+++ b/app/api/create-link-token/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+
+export async function POST(req: NextRequest) {
+  try {
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const supabaseUrl = process.env.SUPABASE_URL!;
+    const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+    const supabase = createClient(supabaseUrl, serviceRole, {
+      global: { headers: { Authorization: authHeader } },
+    });
+
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+    if (userError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const baseUrl =
+      process.env.PLAID_ENV === "production"
+        ? "https://production.plaid.com"
+        : process.env.PLAID_ENV === "development"
+        ? "https://development.plaid.com"
+        : "https://sandbox.plaid.com";
+
+    const apiResponse = await fetch(`${baseUrl}/link/token/create`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "PLAID-CLIENT-ID": process.env.PLAID_CLIENT_ID!,
+        "PLAID-SECRET": process.env.PLAID_SECRET!,
+      },
+      body: JSON.stringify({
+        user: { client_user_id: user.id },
+        client_name: "Budgeting App",
+        products: ["transactions"],
+        language: "en",
+        country_codes: ["US"],
+      }),
+    });
+
+    const plaidData = await apiResponse.json();
+    if (!apiResponse.ok) {
+      console.error("Plaid error", plaidData);
+      return NextResponse.json(
+        { error: "Failed to create link token" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ link_token: plaidData.link_token });
+  } catch (err) {
+    console.error("Error creating link token", err);
+    return NextResponse.json(
+      { error: "Failed to create link token" },
+      { status: 500 }
+    );
+  }
+}

--- a/components/ConnectBank.tsx
+++ b/components/ConnectBank.tsx
@@ -2,12 +2,11 @@
 
 import { useState, useEffect, useMemo, useRef } from "react";
 import { usePlaidLink } from "react-plaid-link";
-import { useSession, useSupabaseClient } from "@supabase/auth-helpers-react";
+import { useSession } from "@supabase/auth-helpers-react";
 
 export default function ConnectBank() {
   const [linkToken, setLinkToken] = useState<string | null>(null);
   const session = useSession();
-  const supabase = useSupabaseClient();
   const fetchedRef = useRef(false);
 
   // Fetch the link token once when a valid session is available
@@ -19,17 +18,17 @@ export default function ConnectBank() {
     fetchedRef.current = true;
 
     const fetchLinkToken = async () => {
-
       try {
-        const { data, error } = await supabase.functions.invoke(
-          "create-link-token",
-          {
-            headers: { Authorization: `Bearer ${session.access_token}` },
-          }
-        );
+        const response = await fetch("/api/create-link-token", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${session.access_token}`,
+          },
+        });
+        const data = await response.json();
         console.log("🎯 Received link token response:", data);
 
-        if (!error && data?.link_token) {
+        if (response.ok && data?.link_token) {
           console.log(
             "🎉 Successful response from create-link-token function:",
             data
@@ -38,7 +37,7 @@ export default function ConnectBank() {
           console.log("🪪 Fetched link token value is:", data.link_token);
           console.log("✅ Link token set in state");
         } else {
-          console.error("❌ Failed to get valid link_token", error);
+          console.error("❌ Failed to get valid link_token", data);
         }
       } catch (err) {
         console.error("🔥 Error fetching link token:", err);
@@ -108,7 +107,7 @@ export default function ConnectBank() {
           }
         },
       }),
-      [token, session]
+      [token]
     );
 
     const plaid = usePlaidLink(config);

--- a/components/auth/AuthGuard.tsx
+++ b/components/auth/AuthGuard.tsx
@@ -20,7 +20,7 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
     }
 
     checkUser()
-  }, [router])
+  }, [router, supabase])
 
   if (loading) {
     return <div className="p-4 text-muted-foreground text-sm">Checking session...</div>


### PR DESCRIPTION
## Summary
- use a Next.js API route instead of Supabase edge functions for link token creation
- handle Plaid link token creation via fetch and set link token state
- fix linter warnings in ConnectBank and AuthGuard

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_683f9625784c832a85f9890676c5b1b2