### PR TITLE
Align Supabase env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ To learn more about Next.js, take a look at the following resources:
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 
+## Environment Variables
+
+The application expects the following Supabase environment variables to be set:
+
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+
+These variables are used in both the Next.js API routes and the Supabase Edge Functions.
+
 ## Deploy on Vercel
 
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.

--- a/supabase/functions/create-link-token/index.ts
+++ b/supabase/functions/create-link-token/index.ts
@@ -12,8 +12,8 @@ serve(async (req) => {
 
   // Supabase auth
   const supabase = createClient(
-    Deno.env.get("SB_URL")!,
-    Deno.env.get("SERVICE_ROLE_KEY")!,
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
     { global: { headers: { Authorization: authHeader } } }
   );
 
@@ -22,8 +22,8 @@ serve(async (req) => {
     return new Response("Unauthorized", { status: 401 });
   }
 console.log("🔐 Environment check", {
-  SB_URL: Deno.env.get("SB_URL"),
-  SERVICE_ROLE_KEY: Deno.env.get("SERVICE_ROLE_KEY")?.substring(0, 6), // just partial for safety
+  SUPABASE_URL: Deno.env.get("SUPABASE_URL"),
+  SUPABASE_SERVICE_ROLE_KEY: Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")?.substring(0, 6), // just partial for safety
   PLAID_ENV: Deno.env.get("PLAID_ENV"),
   PLAID_CLIENT_ID: Deno.env.get("PLAID_CLIENT_ID"),
   PLAID_SECRET: Deno.env.get("PLAID_SECRET")?.substring(0, 4),


### PR DESCRIPTION
## Summary
- use `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` in the create-link-token function
- document required Supabase environment variables

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683f988a5560832aa9b0e25fe4e3cc9d