### PR TITLE
Improve Plaid token error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ PLAID_CLIENT_ID=
 PLAID_SECRET=
 ```
 
+If you see `Failed to create link token` in the browser console, check that your
+Plaid and Supabase credentials are correctly set in `.env`.
+
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## Configuration


### PR DESCRIPTION
## Summary
- refine error messages when creating a Plaid link token
- show server misconfiguration details
- document the failure case in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683f9a5933b4832aad7964099ffcdec9