### PR TITLE
Improve Plaid token error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ PLAID_CLIENT_ID=
 PLAID_SECRET=
 ```
 
+If you see `Failed to create link token` or `Server misconfigured` in the
+browser console, verify that all Plaid and Supabase environment variables are
+set correctly in `.env`.
+
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## Configuration

--- a/app/api/create-link-token/route.ts
+++ b/app/api/create-link-token/route.ts
@@ -8,9 +8,35 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const supabaseUrl = process.env.SUPABASE_URL!;
-    const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-    const supabase = createClient(supabaseUrl, serviceRole, {
+    const {
+      SUPABASE_URL,
+      SUPABASE_SERVICE_ROLE_KEY,
+      PLAID_CLIENT_ID,
+      PLAID_SECRET,
+      PLAID_ENV,
+    } = process.env;
+
+    const missingEnv = [
+      ["SUPABASE_URL", SUPABASE_URL],
+      ["SUPABASE_SERVICE_ROLE_KEY", SUPABASE_SERVICE_ROLE_KEY],
+      ["PLAID_CLIENT_ID", PLAID_CLIENT_ID],
+      ["PLAID_SECRET", PLAID_SECRET],
+    ]
+      .filter(([, value]) => !value)
+      .map(([name]) => name);
+
+    if (missingEnv.length) {
+      console.error("Missing configuration", missingEnv);
+      return NextResponse.json(
+        {
+          error: `Server misconfigured: missing ${missingEnv.join(", ")}`,
+          missing: missingEnv,
+        },
+        { status: 500 }
+      );
+    }
+
+    const supabase = createClient(SUPABASE_URL!, SUPABASE_SERVICE_ROLE_KEY!, {
       global: { headers: { Authorization: authHeader } },
     });
 
@@ -23,9 +49,9 @@ export async function POST(req: NextRequest) {
     }
 
     const baseUrl =
-      process.env.PLAID_ENV === "production"
+      PLAID_ENV === "production"
         ? "https://production.plaid.com"
-        : process.env.PLAID_ENV === "development"
+        : PLAID_ENV === "development"
         ? "https://development.plaid.com"
         : "https://sandbox.plaid.com";
 
@@ -33,8 +59,8 @@ export async function POST(req: NextRequest) {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "PLAID-CLIENT-ID": process.env.PLAID_CLIENT_ID!,
-        "PLAID-SECRET": process.env.PLAID_SECRET!,
+        "PLAID-CLIENT-ID": PLAID_CLIENT_ID,
+        "PLAID-SECRET": PLAID_SECRET,
       },
       body: JSON.stringify({
         user: { client_user_id: user.id },
@@ -49,7 +75,7 @@ export async function POST(req: NextRequest) {
     if (!apiResponse.ok) {
       console.error("Plaid error", plaidData);
       return NextResponse.json(
-        { error: "Failed to create link token" },
+        { error: plaidData?.error_message || "Failed to create link token" },
         { status: 500 }
       );
     }
@@ -58,7 +84,7 @@ export async function POST(req: NextRequest) {
   } catch (err) {
     console.error("Error creating link token", err);
     return NextResponse.json(
-      { error: "Failed to create link token" },
+      { error: (err as Error).message || "Failed to create link token" },
       { status: 500 }
     );
   }


### PR DESCRIPTION
## Summary
- refine error messages when creating a Plaid link token
- show which environment variables are missing
- document the failure case in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683f9a5933b4832aad7964099ffcdec9