### PR TITLE
Fix Plaid warning by disabling strict mode

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  reactStrictMode: false,
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- disable React `strict` mode so Plaid Link script only initializes once

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_683fab3d2ac8832a86cb6e9204ae1307