### PR TITLE
Fix Plaid API flow and add client helpers

### DIFF
--- a/components/ConnectBank.tsx
+++ b/components/ConnectBank.tsx
@@ -124,7 +124,7 @@ export default function ConnectBank() {
                 "Content-Type": "application/json",
                 Authorization: session ? `Bearer ${session.access_token}` : "",
               },
-              body: JSON.stringify({ user_id }),
+              body: JSON.stringify({ plaidItemId: item_id }),
             });
 
             await fetch("/api/plaid/transactions/sync", {
@@ -133,7 +133,7 @@ export default function ConnectBank() {
                 "Content-Type": "application/json",
                 Authorization: session ? `Bearer ${session.access_token}` : "",
               },
-              body: JSON.stringify({ user_id }),
+              body: JSON.stringify({ plaidItemId: item_id }),
             });
           } else {
             const errorData = await response.json();

--- a/lib/plaid.ts
+++ b/lib/plaid.ts
@@ -1,0 +1,25 @@
+import { Configuration, PlaidApi, PlaidEnvironments } from 'plaid'
+
+export function getPlaidClient() {
+  const { PLAID_CLIENT_ID, PLAID_SECRET, PLAID_ENV } = process.env
+  if (!PLAID_CLIENT_ID || !PLAID_SECRET) {
+    throw new Error('Missing Plaid credentials')
+  }
+  const env =
+    PLAID_ENV === 'production'
+      ? PlaidEnvironments.production
+      : PLAID_ENV === 'development'
+      ? PlaidEnvironments.development
+      : PlaidEnvironments.sandbox
+
+  const config = new Configuration({
+    basePath: env,
+    baseOptions: {
+      headers: {
+        'PLAID-CLIENT-ID': PLAID_CLIENT_ID,
+        'PLAID-SECRET': PLAID_SECRET,
+      },
+    },
+  })
+  return new PlaidApi(config)
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,0 +1,6 @@
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+
+export const createServerSupabaseClient = () => {
+  return createRouteHandlerClient({ cookies })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-plaid-link": "^4.0.1",
-        "tailwind-merge": "^3.3.0"
+        "tailwind-merge": "^3.3.0",
+        "plaid": "^13.4.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-plaid-link": "^4.0.1",
+    "plaid": "^13.4.0",
     "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add Plaid helper to create a client
- add server-side supabase helper using modern `createRouteHandlerClient`
- fix Plaid accounts and transactions endpoints to read tokens from DB
- rename misnamed transactions route and update ConnectBank to send `plaidItemId`
- add Plaid dependency

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68403c9edf88832a91c962e176a519d2