### PR TITLE
Fix Plaid item id handling

### DIFF
--- a/app/api/plaid/exchange-public-token/route.ts
+++ b/app/api/plaid/exchange-public-token/route.ts
@@ -42,7 +42,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Failed to update Supabase" }, { status: 500 });
     }
 
-    return NextResponse.json({ success: true });
+    return NextResponse.json({ success: true, plaid_item_id: plaidData.item_id });
   } catch (err) {
     console.error("Unexpected error in exchange route:", err);
     return NextResponse.json({ error: "Server error" }, { status: 500 });

--- a/components/ConnectBank.tsx
+++ b/components/ConnectBank.tsx
@@ -90,6 +90,7 @@ export default function ConnectBank() {
             const { item_id } = await response.json();
             console.log("🔐 Public token stored successfully");
 
+            let plaidItemId = item_id;
             if (item_id) {
               const exchangeRes = await fetch(
                 "/api/plaid/exchange-public-token",
@@ -106,6 +107,8 @@ export default function ConnectBank() {
               );
 
               if (exchangeRes.ok) {
+                const exchangeData = await exchangeRes.json();
+                plaidItemId = exchangeData.plaid_item_id || item_id;
                 console.log(
                   "🔄 Successfully exchanged public token for access token"
                 );
@@ -124,7 +127,7 @@ export default function ConnectBank() {
                 "Content-Type": "application/json",
                 Authorization: session ? `Bearer ${session.access_token}` : "",
               },
-              body: JSON.stringify({ plaidItemId: item_id }),
+              body: JSON.stringify({ plaidItemId }),
             });
 
             await fetch("/api/plaid/transactions/sync", {
@@ -133,7 +136,7 @@ export default function ConnectBank() {
                 "Content-Type": "application/json",
                 Authorization: session ? `Bearer ${session.access_token}` : "",
               },
-              body: JSON.stringify({ plaidItemId: item_id }),
+              body: JSON.stringify({ plaidItemId }),
             });
           } else {
             const errorData = await response.json();


### PR DESCRIPTION
## Summary
- return `plaid_item_id` when exchanging the public token
- propagate that `plaid_item_id` in the Plaid link callback when fetching accounts and transactions

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840475cbe10832a8d9bd3d82c623d4a