### PR TITLE
Handle legacy plaid item ids

### DIFF
--- a/app/api/plaid/accounts/route.ts
+++ b/app/api/plaid/accounts/route.ts
@@ -24,18 +24,32 @@ export async function POST(req: Request) {
 
   const { plaidItemId } = parsed.data;
 
-  const { data: item, error: itemError } = await supabase
+  const {
+    data: initialItem,
+    error: itemError,
+  } = await supabase
     .from('plaid_items')
     .select('access_token')
     .eq('plaid_item_id', plaidItemId)
     .single();
 
+  let item = initialItem;
+
   if (itemError || !item?.access_token) {
-    console.error('Failed to retrieve access token', itemError);
-    return NextResponse.json(
-      { error: 'Missing access token' },
-      { status: 500 }
-    );
+    const { data: legacyItem, error: legacyError } = await supabase
+      .from('plaid_items')
+      .select('access_token')
+      .eq('id', plaidItemId)
+      .single();
+
+    if (legacyError || !legacyItem?.access_token) {
+      console.error('Failed to retrieve access token', itemError || legacyError);
+      return NextResponse.json(
+        { error: 'Missing access token' },
+        { status: 500 }
+      );
+    }
+    item = legacyItem;
   }
 
   const plaid = getPlaidClient();

--- a/app/api/plaid/transactions/sync/route.ts
+++ b/app/api/plaid/transactions/sync/route.ts
@@ -29,18 +29,32 @@ export async function POST(req: Request) {
 
   const { plaidItemId } = parsed.data;
 
-  const { data: item, error: itemError } = await supabase
+  const {
+    data: initialItem,
+    error: itemError,
+  } = await supabase
     .from('plaid_items')
     .select('access_token')
     .eq('plaid_item_id', plaidItemId)
     .single();
 
+  let item = initialItem;
+
   if (itemError || !item?.access_token) {
-    console.error('Failed to retrieve access token', itemError);
-    return NextResponse.json(
-      { error: 'Missing access token' },
-      { status: 500 }
-    );
+    const { data: legacyItem, error: legacyError } = await supabase
+      .from('plaid_items')
+      .select('access_token')
+      .eq('id', plaidItemId)
+      .single();
+
+    if (legacyError || !legacyItem?.access_token) {
+      console.error('Failed to retrieve access token', itemError || legacyError);
+      return NextResponse.json(
+        { error: 'Missing access token' },
+        { status: 500 }
+      );
+    }
+    item = legacyItem;
   }
 
   const plaid = getPlaidClient();


### PR DESCRIPTION
## Summary
- support fallback plaid item lookup by database id when plaid_item_id not found

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_684049822480832a82ef3235ff4537ca