### PR TITLE
Fix paycheck end date handling

### DIFF
--- a/app/paycheck/page.tsx
+++ b/app/paycheck/page.tsx
@@ -7,7 +7,6 @@ import { supabase } from "@/lib/supabase/client";
 import { generatePaycheckDates } from "@/lib/utils/generatePaycheckDates";
 import { getPaycheckRange, getIncomeHitDate } from "@/lib/utils/date/paycheck";
 import { formatDateRange, formatDisplayDate } from "@/lib/utils/date/format";
-import { addDays } from "date-fns";
 import { FixedItem } from "@/types";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -179,11 +178,8 @@ export default function PaycheckPage() {
 
     setIsLoadingIncome(true);
 
-    const periodStart = new Date(selectedDate.adjustedDate);
-    const periodEnd = nextPaycheck
-      ? new Date(nextPaycheck.adjustedDate)
-      : addDays(periodStart, 13);
-    periodEnd.setDate(periodEnd.getDate() - 1);
+    const periodStart = start;
+    const periodEnd = end;
 
     supabase
       .from("income_sources")
@@ -241,11 +237,8 @@ export default function PaycheckPage() {
 
     setIsLoadingFixedItems(true);
 
-    const periodStart = new Date(selectedDate.adjustedDate);
-    const periodEnd = nextPaycheck
-      ? new Date(nextPaycheck.adjustedDate)
-      : addDays(periodStart, 13);
-    periodEnd.setDate(periodEnd.getDate() - 1);
+    const periodStart = start;
+    const periodEnd = end;
 
     supabase
       .from("fixed_items")


### PR DESCRIPTION
## Summary
- ensure paycheck period uses start/end values from `getPaycheckRange`
- drop unused `addDays` import

## Testing
- `npm run lint` *(fails: '@typescript-eslint/no-unused-vars' and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68487beef270832ab1151ee8a3618763