### PR TITLE
Fix paycheck income filtering

### DIFF
--- a/app/paycheck/page.tsx
+++ b/app/paycheck/page.tsx
@@ -196,19 +196,18 @@ export default function PaycheckPage() {
           .filter((row) => {
             const starts = row.start_date ? new Date(row.start_date) : null;
             const isPaycheck = row.name?.toLowerCase().includes("paycheck");
-            const hitsInPeriod =
-              isPaycheck ||
-              getIncomeHitDate(
-                {
-                  ...row,
-                  due_days: row.due_days ?? undefined,
-                  weekly_day: row.weekly_day ?? undefined,
-                  frequency: row.frequency ?? undefined,
-                  start_date: row.start_date ?? undefined,
-                },
-                periodStart,
-                periodEnd
-              );
+            const hitDates = getIncomeHitDate(
+              {
+                ...row,
+                due_days: row.due_days ?? undefined,
+                weekly_day: row.weekly_day ?? undefined,
+                frequency: row.frequency ?? undefined,
+                start_date: row.start_date ?? undefined,
+              },
+              periodStart,
+              periodEnd
+            );
+            const hitsInPeriod = isPaycheck || hitDates.length > 0;
             return (!starts || starts <= periodEnd) && hitsInPeriod;
           })
           .sort(


### PR DESCRIPTION
## Summary
- filter income list correctly using the pay period

## Testing
- `npm run lint` *(fails: Do not use "@ts-nocheck" and other existing lint errors)*
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_68487e6d2e98832a9ad9483b6a7b9da0