### PR TITLE
Avoid recomputing paycheck breakdown

### DIFF
--- a/app/paycheck/page.tsx
+++ b/app/paycheck/page.tsx
@@ -39,6 +39,42 @@ export default function PaycheckPage() {
   const [incomeSources, setIncomeSources] = useState<IncomeSource[]>([]);
   const [showIncomeBreakdown, setShowIncomeBreakdown] = useState(false);
 
+  const incomeBreakdown = useMemo(() => {
+    if (!selectedDate || !start || !end) return [];
+    return incomeSources
+      .map((source) => {
+        if (source.name === "Paycheck") {
+          return {
+            id: source.id,
+            name: source.name,
+            amount: source.amount,
+            displayDate: formatDisplayDate(selectedDate.adjustedDate),
+          };
+        }
+
+        const hitDates = getIncomeHitDate(
+          {
+            ...source,
+            due_days: source.due_days?.map(String) ?? undefined,
+            weekly_day: source.weekly_day ?? undefined,
+            frequency: source.frequency ?? undefined,
+            start_date: source.start_date ?? undefined,
+          },
+          start,
+          end
+        );
+        if (!hitDates.length) return null;
+
+        return {
+          id: source.id,
+          name: source.name,
+          amount: source.amount,
+          displayDate: formatDisplayDate(hitDates[0].toISOString()),
+        };
+      })
+      .filter(Boolean) as { id: string; name: string; amount: number; displayDate: string }[];
+  }, [incomeSources, selectedDate, start, end]);
+
   const [fixedItems, setFixedItems] = useState<FixedItem[]>([]);
   const [vaultItems, setVaultItems] = useState<FixedItem[]>([]);
 
@@ -386,41 +422,11 @@ export default function PaycheckPage() {
 
               {showIncomeBreakdown && (
                 <ul className="ml-4 mt-2 list-disc text-xs">
-                  {incomeSources.map((source) => {
-                    // Revised logic: Only show if date falls in current period
-                    if (source.name === "Paycheck") {
-                      const displayDate = formatDisplayDate(
-                        selectedDate.adjustedDate
-                      );
-                      return (
-                        <li key={source.id}>
-                          {source.name} (${source.amount.toFixed(2)}) —{" "}
-                          {displayDate}
-                        </li>
-                      );
-                    }
-                    const hitDates = getIncomeHitDate(
-                      {
-                        ...source,
-                        due_days: source.due_days?.map(String) ?? undefined,
-                        weekly_day: source.weekly_day ?? undefined,
-                        frequency: source.frequency ?? undefined,
-                        start_date: source.start_date ?? undefined,
-                      },
-                      start,
-                      end
-                    );
-                    if (!hitDates.length) return null;
-                    const displayDate = formatDisplayDate(
-                      hitDates[0].toISOString()
-                    );
-                    return (
-                      <li key={source.id}>
-                        {source.name} (${source.amount.toFixed(2)}) —{" "}
-                        {displayDate}
-                      </li>
-                    );
-                  })}
+                  {incomeBreakdown.map((item) => (
+                    <li key={item.id}>
+                      {item.name} (${item.amount.toFixed(2)}) — {item.displayDate}
+                    </li>
+                  ))}
                 </ul>
               )}
             </div>


### PR DESCRIPTION
## Summary
- compute paycheck income breakdown using `useMemo`
- reuse cached breakdown when toggling Show/Hide Breakdown

## Testing
- `npm run lint` *(fails: various eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6848827b2738832ab373cfd5dc2fa6c3