### PR TITLE
Add income sources management

### DIFF
--- a/app/settings/income-sources/page.tsx
+++ b/app/settings/income-sources/page.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import type { IncomeSource } from "@/types";
+import { AuthGuard } from "@/components/auth/AuthGuard";
+import { IncomeSourcesList } from "@/components/income-sources/IncomeSourcesList";
+import { IncomeSourceForm } from "@/components/income-sources/IncomeSourceForm";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+export default function IncomeSourcesPage() {
+  const [showForm, setShowForm] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [editItem, setEditItem] = useState<IncomeSource | null>(null);
+
+  return (
+    <AuthGuard>
+      <div className="hidden force-scrollbar-classes" />
+      <div className="space-y-4">
+        <h1 className="text-3xl font-bold text-foreground">Income Sources</h1>
+        <p className="text-sm text-muted-foreground">
+          Manage your regular sources of income.
+        </p>
+
+        <Button
+          onClick={() => {
+            setEditItem(null);
+            setShowForm(true);
+          }}
+        >
+          + Add Income Source
+        </Button>
+
+        <Dialog open={showForm} onOpenChange={setShowForm}>
+          <DialogContent
+            className="max-w-xl p-6 shadow-xl ring-border"
+            header={
+              <DialogHeader>
+                <DialogTitle>
+                  {editItem ? `Edit Income Source` : `Add Income Source`}
+                </DialogTitle>
+              </DialogHeader>
+            }
+          >
+            <IncomeSourceForm
+              source={editItem}
+              onClose={() => setShowForm(false)}
+              onSave={() => {
+                setShowForm(false);
+                setRefreshKey((prev) => prev + 1);
+              }}
+            />
+          </DialogContent>
+        </Dialog>
+
+        <IncomeSourcesList
+          key={refreshKey}
+          editable
+          onEdit={(item) => {
+            setEditItem(item);
+            setShowForm(true);
+          }}
+        />
+      </div>
+    </AuthGuard>
+  );
+}
+

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -20,7 +20,12 @@ export default function SettingsPage() {
             Income Setup
           </h2>
           <div className="text-sm text-muted-foreground">
-            [Placeholder for income sources and schedules]
+            <a
+              href="/settings/income-sources"
+              className="text-primary underline hover:opacity-80"
+            >
+              Manage income sources
+            </a>
           </div>
         </section>
 

--- a/components/income-sources/IncomeSourceForm.tsx
+++ b/components/income-sources/IncomeSourceForm.tsx
@@ -1,0 +1,400 @@
+"use client";
+
+import { useState } from "react";
+import { supabase } from "@/lib/supabase/client";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Select } from "@/components/ui/select";
+import { DateInput } from "@/components/ui/date";
+import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
+import type { IncomeSource, IncomeSourceFormProps } from "@/types";
+
+export function IncomeSourceForm({
+  source,
+  onClose,
+  onSave,
+}: IncomeSourceFormProps) {
+  const [formData, setFormData] = useState<
+    Omit<IncomeSource, "id"> & { transaction_match_keywords?: string[] }
+  >({
+    name: source?.name ?? "",
+    amount: source?.amount ?? 0,
+    frequency: source?.frequency ?? "Monthly",
+    due_days: source?.due_days ?? [],
+    start_date: source?.start_date ?? null,
+    notes: source?.notes ?? "",
+    weekly_day: source?.weekly_day ?? "",
+    transaction_match_keywords: source?.transaction_match_keywords ?? [],
+  });
+
+  const [keywordInput, setKeywordInput] = useState(
+    source?.transaction_match_keywords?.join(", ") ?? ""
+  );
+
+  const [showStartDate, setShowStartDate] = useState<boolean>(
+    !!formData.start_date
+  );
+
+  const handleChange = (
+    e: React.ChangeEvent<
+      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+    >
+  ) => {
+    const { name, value, type } = e.target as HTMLInputElement;
+    if (name === "due_days") {
+      const selectedOptions = Array.from(
+        (e.target as HTMLSelectElement).selectedOptions
+      ).map((opt) => opt.value);
+      setFormData((prev) => ({ ...prev, due_days: selectedOptions }));
+      return;
+    }
+    const checked = (e.target as HTMLInputElement).checked;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: type === "checkbox" ? checked : value,
+    }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    const payload = {
+      ...formData,
+      user_id: user?.id,
+    };
+    if (source?.id) {
+      await supabase.from("income_sources").update(payload).eq("id", source.id);
+    } else {
+      await supabase.from("income_sources").insert(payload);
+    }
+
+    onSave();
+    onClose();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="bg-muted/10 border border-border ring-border  rounded-lg p-6 space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-foreground font-semibold">
+            Name
+          </label>
+          <Input
+            name="name"
+            value={formData.name}
+            onChange={handleChange}
+            required
+            className="bg-card text-foreground border-border"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-foreground font-semibold">
+            Amount
+          </label>
+          <Input
+            type="number"
+            name="amount"
+            value={formData.amount}
+            onChange={handleChange}
+            required
+            className="bg-card text-foreground border-border"
+          />
+        </div>
+      </div>
+
+      <div className="bg-muted/10 border border-border ring-border  rounded-lg p-6 space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-foreground font-semibold">
+            Frequency
+          </label>
+          <Select
+            name="frequency"
+            value={formData.frequency}
+            onChange={handleChange}
+            className="w-full bg-card text-foreground border-border"
+          >
+            <option>Monthly</option>
+            <option>Biweekly</option>
+            <option>Weekly</option>
+            <option>Yearly</option>
+            <option>Quarterly</option>
+            <option value="Semi-Monthly">Semi-Monthly</option>
+            <option>Per Paycheck</option>
+          </Select>
+          {formData.frequency === "Per Paycheck" && (
+            <p className="text-sm text-muted-foreground mt-1">
+              This income will be included in every paycheck plan.
+            </p>
+          )}
+        </div>
+
+        {["Weekly", "Biweekly"].includes(formData.frequency) && (
+          <div>
+            <label className="block text-sm font-medium text-foreground font-semibold">
+              Weekly Day
+            </label>
+            <Select
+              name="weekly_day"
+              value={formData.weekly_day ?? ""}
+              onChange={handleChange}
+              className="w-full bg-card text-foreground border-border"
+            >
+              <option value="">Select Day</option>
+              {["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"].map(
+                (day) => (
+                  <option key={day} value={day}>
+                    {day}
+                  </option>
+                )
+              )}
+            </Select>
+          </div>
+        )}
+
+        {["Monthly"].includes(formData.frequency) && (
+          <div>
+            <label className="block text-sm font-medium text-foreground font-semibold">
+              Due Day
+            </label>
+            <Select
+              name="due_days"
+              value={formData.due_days?.[0] ?? ""}
+              onChange={(e) =>
+                setFormData((prev) => ({
+                  ...prev,
+                  due_days: [(e.target as HTMLSelectElement).value],
+                }))
+              }
+              className="w-full bg-card text-foreground border-border"
+            >
+              <option value="">Select Day</option>
+              {Array.from({ length: 31 }, (_, i) => {
+                const day = i + 1;
+                const suffix =
+                  day === 1 || day === 21 || day === 31
+                    ? "st"
+                    : day === 2 || day === 22
+                    ? "nd"
+                    : day === 3 || day === 23
+                    ? "rd"
+                    : "th";
+                return (
+                  <option key={day} value={String(day)}>
+                    {day}
+                    {suffix}
+                  </option>
+                );
+              })}
+              <option value="EOM">End of Month</option>
+            </Select>
+          </div>
+        )}
+        {formData.frequency === "Semi-Monthly" && (
+          <div>
+            <label className="block text-sm font-medium text-foreground font-semibold mb-2">
+              Semi-Monthly Due Days
+            </label>
+            <div className="grid grid-cols-2 gap-4">
+              {["1st Half", "2nd Half"].map((label, index) => (
+                <div key={label}>
+                  <label className="block text-xs font-medium text-muted-foreground mb-1">
+                    {label}
+                  </label>
+                  <Select
+                    name={`due_days_${index}`}
+                    value={formData.due_days?.[index] ?? ""}
+                    onChange={(e) => {
+                      const newDueDays = [...(formData.due_days ?? [])];
+                      newDueDays[index] = (e.target as HTMLSelectElement).value;
+                      setFormData((prev) => ({
+                        ...prev,
+                        due_days: newDueDays,
+                      }));
+                    }}
+                    className="w-full bg-card text-foreground border-border"
+                  >
+                    <option value="">Select Day</option>
+                    {Array.from({ length: 31 }, (_, i) => {
+                      const day = i + 1;
+                      const suffix =
+                        day === 1 || day === 21 || day === 31
+                          ? "st"
+                          : day === 2 || day === 22
+                          ? "nd"
+                          : day === 3 || day === 23
+                          ? "rd"
+                          : "th";
+                      return (
+                        <option key={day} value={String(day)}>
+                          {day}
+                          {suffix}
+                        </option>
+                      );
+                    })}
+                    <option value="EOM">End of Month</option>
+                  </Select>
+                </div>
+              ))}
+            </div>
+            <p className="text-sm text-muted-foreground mt-2">
+              Specify two due days per month (e.g. 1st &amp; 15th or 15th &amp; EOM).
+            </p>
+          </div>
+        )}
+        {formData.frequency === "Quarterly" && (
+          <div>
+            <label className="block text-sm font-medium text-foreground font-semibold mb-2">
+              Quarterly Due Days
+            </label>
+            <div className="grid grid-cols-2 gap-4">
+              {["Q1", "Q2", "Q3", "Q4"].map((quarter, index) => (
+                <div key={quarter}>
+                  <label className="block text-xs font-medium text-muted-foreground mb-1">
+                    {quarter}
+                  </label>
+                  <Select
+                    name={`due_days_${index}`}
+                    value={formData.due_days?.[index] ?? ""}
+                    onChange={(e) => {
+                      const newDueDays = [...(formData.due_days ?? [])];
+                      newDueDays[index] = (e.target as HTMLSelectElement).value;
+                      setFormData((prev) => ({
+                        ...prev,
+                        due_days: newDueDays,
+                      }));
+                    }}
+                    className="w-full bg-card text-foreground border-border"
+                  >
+                    <option value="">Select Day</option>
+                    {Array.from({ length: 31 }, (_, i) => {
+                      const day = i + 1;
+                      const suffix =
+                        day === 1 || day === 21 || day === 31
+                          ? "st"
+                          : day === 2 || day === 22
+                          ? "nd"
+                          : day === 3 || day === 23
+                          ? "rd"
+                          : "th";
+                      return (
+                        <option key={day} value={String(day)}>
+                          {day}
+                          {suffix}
+                        </option>
+                      );
+                    })}
+                  </Select>
+                </div>
+              ))}
+            </div>
+            <p className="text-sm text-muted-foreground mt-2">
+              Specify a due day for each quarter in the year.
+            </p>
+          </div>
+        )}
+
+        {["Yearly", "Quarterly", "Weekly", "Biweekly"].includes(
+          formData.frequency
+        ) ? (
+          <div>
+            <label className="block text-sm font-medium text-foreground font-semibold">
+              Start Date
+            </label>
+            <DateInput
+              name="start_date"
+              value={formData.start_date ?? ""}
+              onChange={handleChange}
+              required={[
+                "Weekly",
+                "Biweekly",
+                "Yearly",
+                "Quarterly",
+              ].includes(formData.frequency)}
+            />
+          </div>
+        ) : (
+          <div>
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="toggle_start_date"
+                checked={showStartDate}
+                onChange={() => setShowStartDate((prev) => !prev)}
+              />
+              <label
+                htmlFor="toggle_start_date"
+                className="text-sm text-foreground font-semibold"
+              >
+                Set a Start Date
+              </label>
+            </div>
+            {showStartDate && (
+              <div className="pt-2">
+                <label className="block text-sm font-medium text-foreground font-semibold">
+                  Start Date
+                </label>
+                <DateInput
+                  name="start_date"
+                  value={formData.start_date ?? ""}
+                  onChange={handleChange}
+                />
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="bg-muted/10 border border-border ring-border  rounded-lg p-6 space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-foreground font-semibold">
+            Transaction Match Keywords
+          </label>
+          <Input
+            name="transaction_match_keywords"
+            value={keywordInput}
+            onChange={(e) => setKeywordInput(e.target.value)}
+            onBlur={() =>
+              setFormData((prev) => ({
+                ...prev,
+                transaction_match_keywords: keywordInput
+                  .split(",")
+                  .map((s) => s.trim())
+                  .filter(Boolean),
+              }))
+            }
+            placeholder="e.g. paycheck, salary"
+            className="bg-card text-foreground border-border"
+          />
+        </div>
+      </div>
+
+      <div className="bg-muted/10 border border-border ring-border  rounded-lg p-6 space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-foreground font-semibold">
+            Notes
+          </label>
+          <Textarea
+            name="notes"
+            value={formData.notes ?? ""}
+            onChange={handleChange}
+            className="bg-card text-foreground border-border"
+          />
+        </div>
+      </div>
+
+      <div className="flex justify-end items-center gap-2">
+        <Button type="button" variant="secondary" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button type="submit">
+          {source?.id ? "Update Source" : "Add Source"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+

--- a/components/income-sources/IncomeSourcesList.tsx
+++ b/components/income-sources/IncomeSourcesList.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase/client";
+import type { IncomeSource } from "@/types";
+
+function formatOrdinal(day: string) {
+  const n = parseInt(day, 10);
+  if (isNaN(n)) return day;
+  const suffix = ["th", "st", "nd", "rd"][n % 100 >= 11 && n % 100 <= 13 ? 0 : n % 10] || "th";
+  return `${n}${suffix}`;
+}
+
+function formatDueDay(day: string) {
+  if (day === "EOM") return "at month-end";
+  return `on the ${formatOrdinal(day)}`;
+}
+
+function formatQuarterlyDates(dueDays: string[], startDate: string | null): string {
+  if (!startDate || dueDays.length !== 4) return dueDays.map(formatDueDay).join(", ");
+
+  const start = new Date(startDate);
+  const baseMonth = start.getMonth();
+  const months = [baseMonth, baseMonth + 3, baseMonth + 6, baseMonth + 9];
+
+  return dueDays
+    .map((day, index) => {
+      const monthIndex = months[index] % 12;
+      const date = new Date(2000, monthIndex, parseInt(day));
+      return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+    })
+    .join(", ");
+}
+
+export function IncomeSourcesList({
+  onEdit,
+  editable = false,
+}: {
+  onEdit?: (item: IncomeSource) => void;
+  editable?: boolean;
+}) {
+  const [items, setItems] = useState<IncomeSource[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchItems() {
+      setLoading(true);
+      const { data, error } = await supabase
+        .from("income_sources")
+        .select("*")
+        .order("due_days");
+
+      if (!error && data) {
+        setItems(data);
+      }
+      setLoading(false);
+    }
+
+    fetchItems();
+  }, []);
+
+  if (loading)
+    return <p className="text-muted-foreground">Loading income sources...</p>;
+
+  if (items.length === 0)
+    return <p className="text-muted-foreground">No income sources found.</p>;
+
+  return (
+    <div className="space-y-2">
+      {items.map((item) => (
+        <div
+          key={item.id}
+          className="border border-border ring-border bg-card p-4 rounded-lg"
+        >
+          <div className="text-base font-semibold text-foreground">{item.name}</div>
+          <div className="text-sm text-muted-foreground mt-1">
+            <span className="font-medium">${item.amount.toFixed(2)}</span>
+            {item.frequency === "Monthly" && item.due_days?.length === 1
+              ? ` • Monthly ${formatDueDay(item.due_days[0])}`
+              : item.frequency === "Semi-Monthly" && item.due_days?.length === 2
+              ? ` • Every ${
+                  item.due_days[0] === "EOM"
+                    ? "month-end"
+                    : formatOrdinal(item.due_days[0])
+                } and ${
+                  item.due_days[1] === "EOM"
+                    ? "month-end"
+                    : formatOrdinal(item.due_days[1])
+                }`
+              : item.frequency === "Quarterly" && item.due_days?.length === 4
+              ? ` • Quarterly on ${formatQuarterlyDates(item.due_days, item.start_date)}`
+              : item.frequency === "Yearly" && item.due_days?.length === 1
+              ? ` • Yearly ${formatDueDay(item.due_days[0])}`
+              : item.frequency === "Per Paycheck"
+              ? ` • Every Paycheck`
+              : ""}
+            {item.frequency === "Weekly" && item.weekly_day
+              ? ` • Every ${item.weekly_day}`
+              : item.frequency === "Biweekly" && item.weekly_day
+              ? ` • Every other ${item.weekly_day}`
+              : ""}
+          </div>
+          {item.notes && (
+            <div className="text-sm mt-1 italic text-muted-foreground">
+              {item.notes}
+            </div>
+          )}
+          {editable && onEdit && (
+            <button
+              onClick={() => onEdit(item)}
+              className="text-sm text-primary hover:text-primary/80 underline mt-1 transition-colors"
+            >
+              Edit
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/components/income-sources/IncomeSourcesList.tsx
+++ b/components/income-sources/IncomeSourcesList.tsx
@@ -7,7 +7,9 @@ import type { IncomeSource } from "@/types";
 function formatOrdinal(day: string) {
   const n = parseInt(day, 10);
   if (isNaN(n)) return day;
-  const suffix = ["th", "st", "nd", "rd"][n % 100 >= 11 && n % 100 <= 13 ? 0 : n % 10] || "th";
+  const suffix =
+    ["th", "st", "nd", "rd"][n % 100 >= 11 && n % 100 <= 13 ? 0 : n % 10] ||
+    "th";
   return `${n}${suffix}`;
 }
 
@@ -16,8 +18,12 @@ function formatDueDay(day: string) {
   return `on the ${formatOrdinal(day)}`;
 }
 
-function formatQuarterlyDates(dueDays: string[], startDate: string | null): string {
-  if (!startDate || dueDays.length !== 4) return dueDays.map(formatDueDay).join(", ");
+function formatQuarterlyDates(
+  dueDays: string[],
+  startDate: string | null
+): string {
+  if (!startDate || dueDays.length !== 4)
+    return dueDays.map(formatDueDay).join(", ");
 
   const start = new Date(startDate);
   const baseMonth = start.getMonth();
@@ -27,7 +33,10 @@ function formatQuarterlyDates(dueDays: string[], startDate: string | null): stri
     .map((day, index) => {
       const monthIndex = months[index] % 12;
       const date = new Date(2000, monthIndex, parseInt(day));
-      return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+      return date.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+      });
     })
     .join(", ");
 }
@@ -51,7 +60,12 @@ export function IncomeSourcesList({
         .order("due_days");
 
       if (!error && data) {
-        setItems(data);
+        setItems(
+          data.map((item) => ({
+            ...item,
+            due_days: item.due_days ?? undefined,
+          }))
+        );
       }
       setLoading(false);
     }
@@ -72,7 +86,9 @@ export function IncomeSourcesList({
           key={item.id}
           className="border border-border ring-border bg-card p-4 rounded-lg"
         >
-          <div className="text-base font-semibold text-foreground">{item.name}</div>
+          <div className="text-base font-semibold text-foreground">
+            {item.name}
+          </div>
           <div className="text-sm text-muted-foreground mt-1">
             <span className="font-medium">${item.amount.toFixed(2)}</span>
             {item.frequency === "Monthly" && item.due_days?.length === 1
@@ -88,7 +104,10 @@ export function IncomeSourcesList({
                     : formatOrdinal(item.due_days[1])
                 }`
               : item.frequency === "Quarterly" && item.due_days?.length === 4
-              ? ` • Quarterly on ${formatQuarterlyDates(item.due_days, item.start_date)}`
+              ? ` • Quarterly on ${formatQuarterlyDates(
+                  item.due_days,
+                  item.start_date
+                )}`
               : item.frequency === "Yearly" && item.due_days?.length === 1
               ? ` • Yearly ${formatDueDay(item.due_days[0])}`
               : item.frequency === "Per Paycheck"
@@ -118,4 +137,3 @@ export function IncomeSourcesList({
     </div>
   );
 }
-

--- a/types.ts
+++ b/types.ts
@@ -37,6 +37,24 @@ export type FixedItemFormProps = {
   onSave: () => void;
 };
 
+export type IncomeSource = {
+  id: string;
+  name: string;
+  amount: number;
+  frequency: string;
+  due_days?: string[];
+  start_date: string | null;
+  notes: string | null;
+  weekly_day?: string | null;
+  transaction_match_keywords?: string[] | null;
+};
+
+export type IncomeSourceFormProps = {
+  source?: IncomeSource | null;
+  onClose: () => void;
+  onSave: () => void;
+};
+
 export type PlaidAccount = {
   account_id: string;
   name: string;


### PR DESCRIPTION
## Summary
- create IncomeSource types
- create IncomeSourceForm and IncomeSourcesList components
- add new /settings/income-sources page
- link to new page from main settings page

## Testing
- `npm run lint` *(fails: cookieStore unused, '_' defined but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68489a4c4774832a96914f476a9e6e1d