### PR TITLE
Implement delete actions for fixed items and income sources

### DIFF
--- a/components/fixed-items/FixedItemForm.tsx
+++ b/components/fixed-items/FixedItemForm.tsx
@@ -487,6 +487,29 @@ export function FixedItemForm({ item, onClose, onSave }: FixedItemFormProps) {
         </div>
 
         <div className="flex justify-end items-center gap-2">
+          {item?.id && (
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={async () => {
+                if (
+                  confirm(
+                    "Are you sure you want to delete this fixed item?"
+                  )
+                ) {
+                  await supabase
+                    .from("fixed_items")
+                    .delete()
+                    .eq("id", item.id);
+                  onSave();
+                  onClose();
+                }
+              }}
+              className="mr-auto"
+            >
+              Delete
+            </Button>
+          )}
           <Button type="button" variant="secondary" onClick={onClose}>
             Cancel
           </Button>

--- a/components/fixed-items/FixedItemsList.tsx
+++ b/components/fixed-items/FixedItemsList.tsx
@@ -182,13 +182,37 @@ export function FixedItemsList({
                       {item.notes}
                     </div>
                   )}
-                  {editable && onEdit && (
-                    <button
-                      onClick={() => onEdit(item)}
-                      className="text-sm text-primary hover:text-primary/80 underline mt-1 transition-colors"
-                    >
-                      Edit
-                    </button>
+                  {editable && (
+                    <div className="flex gap-2 mt-1">
+                      {onEdit && (
+                        <button
+                          onClick={() => onEdit(item)}
+                          className="text-sm text-primary hover:text-primary/80 underline transition-colors"
+                        >
+                          Edit
+                        </button>
+                      )}
+                      <button
+                        onClick={async () => {
+                          if (
+                            confirm(
+                              "Are you sure you want to delete this fixed item?"
+                            )
+                          ) {
+                            await supabase
+                              .from("fixed_items")
+                              .delete()
+                              .eq("id", item.id);
+                            setItems((prev) =>
+                              prev.filter((i) => i.id !== item.id)
+                            );
+                          }
+                        }}
+                        className="text-sm text-destructive hover:text-destructive/80 underline transition-colors"
+                      >
+                        Delete
+                      </button>
+                    </div>
                   )}
                 </div>
               ))}

--- a/components/income-sources/IncomeSourceForm.tsx
+++ b/components/income-sources/IncomeSourceForm.tsx
@@ -387,6 +387,29 @@ export function IncomeSourceForm({
       </div>
 
       <div className="flex justify-end items-center gap-2">
+        {source?.id && (
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={async () => {
+              if (
+                confirm(
+                  "Are you sure you want to delete this income source?"
+                )
+              ) {
+                await supabase
+                  .from("income_sources")
+                  .delete()
+                  .eq("id", source.id);
+                onSave();
+                onClose();
+              }
+            }}
+            className="mr-auto"
+          >
+            Delete
+          </Button>
+        )}
         <Button type="button" variant="secondary" onClick={onClose}>
           Cancel
         </Button>

--- a/components/income-sources/IncomeSourcesList.tsx
+++ b/components/income-sources/IncomeSourcesList.tsx
@@ -124,13 +124,35 @@ export function IncomeSourcesList({
               {item.notes}
             </div>
           )}
-          {editable && onEdit && (
-            <button
-              onClick={() => onEdit(item)}
-              className="text-sm text-primary hover:text-primary/80 underline mt-1 transition-colors"
-            >
-              Edit
-            </button>
+          {editable && (
+            <div className="flex gap-2 mt-1">
+              {onEdit && (
+                <button
+                  onClick={() => onEdit(item)}
+                  className="text-sm text-primary hover:text-primary/80 underline transition-colors"
+                >
+                  Edit
+                </button>
+              )}
+              <button
+                onClick={async () => {
+                  if (
+                    confirm(
+                      "Are you sure you want to delete this income source?"
+                    )
+                  ) {
+                    await supabase
+                      .from("income_sources")
+                      .delete()
+                      .eq("id", item.id);
+                    setItems((prev) => prev.filter((i) => i.id !== item.id));
+                  }
+                }}
+                className="text-sm text-destructive hover:text-destructive/80 underline transition-colors"
+              >
+                Delete
+              </button>
+            </div>
           )}
         </div>
       ))}


### PR DESCRIPTION
## Summary
- enable deleting fixed items while editing
- allow deleting income sources while editing
- show delete buttons on fixed items list
- show delete buttons on income sources list

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars, etc.)*
- `npm run build` *(fails to fetch fonts: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6848a6cf8544832aab907811caf06e6f