### PR TITLE
Ensure consistent dialog headers

### DIFF
--- a/app/settings/fixed-items/page.tsx
+++ b/app/settings/fixed-items/page.tsx
@@ -52,10 +52,14 @@ export default function FixedItemsPage() {
           open={showCategoryManager}
           onOpenChange={setShowCategoryManager}
         >
-          <DialogContent className="max-w-md p-6 shadow-xl ring-border">
-            <DialogHeader>
-              <DialogTitle>Manage Categories</DialogTitle>
-            </DialogHeader>
+          <DialogContent
+            className="max-w-md p-6 shadow-xl ring-border"
+            header={
+              <DialogHeader>
+                <DialogTitle>Manage Categories</DialogTitle>
+              </DialogHeader>
+            }
+          >
             <CategoryManager />
           </DialogContent>
         </Dialog>


### PR DESCRIPTION
## Summary
- use `DialogContent` header prop for Manage Categories dialog

## Testing
- `npm run lint` *(fails: `cookieStore` is assigned a value but never used)*

------
https://chatgpt.com/codex/tasks/task_e_6848b5e958a4832a80e5541fd8d29924