### PR TITLE
Add basic project documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,27 @@
+# Code of Conduct
+
+This project follows the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) to foster an open and welcoming environment.
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior by participants include:
+
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the maintainers. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing to Budgeting App
+
+Thank you for taking the time to contribute! The following guidelines will help you set up a development environment and submit changes.
+
+## Getting Started
+
+1. Fork the repository and clone your fork.
+2. Install dependencies with `npm install`.
+3. Copy `.env.example` to `.env` and fill in the required keys.
+4. Start the local Supabase stack with `supabase start`.
+5. Run the development server using `npm run dev`.
+
+## Development
+
+- Use `npm run lint` to check code style before committing.
+- Commit descriptive messages and open a pull request targeting the `main` branch.
+- If adding a new feature or fixing a bug, please include relevant documentation updates in the `docs/` directory.
+
+## Communication
+
+For major changes or proposals, open an issue to discuss them before creating a pull request.
+

--- a/README.md
+++ b/README.md
@@ -1,27 +1,40 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
-This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
+# Budgeting App
+
+A personal finance manager built with Next.js, Supabase, and Plaid. The application lets you connect bank accounts, track transactions, and organize money into vaults.
+
+## Features
+
+- Authenticate and store user data with Supabase
+- Connect bank accounts through Plaid to import transactions
+- Manage vaults and categorize expenses
+- Dashboard showing recent activity and paycheck summaries
 
 ## Getting Started
 
-First, run the development server:
+### Prerequisites
+
+- Node.js 18 or higher
+- Supabase CLI installed for local development
+
+### Installation
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+npm install
+cp .env.example .env  # add your Supabase and Plaid credentials
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Start the local Supabase stack and run the dev server:
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+```bash
+supabase start
+npm run dev
+```
+
+Open <http://localhost:3000> in your browser.
 
 ## Environment Variables
 
-Copy `.env.example` to `.env` and provide the values for your environment. The following variables are required:
+The following variables must be provided in `.env`:
 
 ```
 SUPABASE_URL=
@@ -32,56 +45,22 @@ PLAID_CLIENT_ID=
 PLAID_SECRET=
 ```
 
-If you see `Failed to create link token` in the browser console, check that your
-Plaid and Supabase credentials are correctly set in `.env`.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Configuration
-
-Copy `.env.example` to `.env` and provide your credentials for Supabase and Plaid:
-
-```bash
-cp .env.example .env
-```
-
-```
-SUPABASE_URL=your-supabase-url
-SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
-PLAID_CLIENT_ID=your-plaid-client-id
-PLAID_SECRET=your-plaid-secret
-PLAID_ENV=sandbox
-```
-
 `PLAID_ENV` supports `sandbox`, `development`, or `production`.
 
-To run the Supabase stack locally, install the Supabase CLI and run:
+## Project Structure
 
-```bash
-supabase start
-```
+- `app/` – Next.js routes and pages
+- `components/` – Shared UI and feature components
+- `lib/` – Utility libraries including Supabase helpers
+- `supabase/` – Local Supabase configuration
 
+Additional guides are available in the [docs](docs/) directory.
 
-## Learn More
+## Contributing
 
-To learn more about Next.js, take a look at the following resources:
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on developing and submitting changes.
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## License
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
 
-## Environment Variables
-
-The application expects the following Supabase environment variables to be set:
-
-- `SUPABASE_URL`
-- `SUPABASE_SERVICE_ROLE_KEY`
-
-These variables are used in the Next.js API routes.
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,0 +1,26 @@
+# Project Architecture
+
+The Budgeting App is built with the Next.js App Router and TypeScript. Supabase provides the database and authentication layer, while Plaid is used to link bank accounts and fetch transactions.
+
+```
+Next.js (App Router)
+└── Supabase (database & auth)
+    └── Plaid integration for bank data
+```
+
+### Key Directories
+
+- `app/` – Application routes and pages
+- `components/` – Reusable React components
+- `lib/` – Utility functions and Supabase helpers
+- `supabase/` – Local Supabase configuration
+
+### Data Flow
+
+1. Users authenticate via Supabase.
+2. Connected bank accounts through Plaid are stored in Supabase.
+3. Transactions are synced from Plaid to Supabase using API routes.
+4. Pages query Supabase to display data in the dashboard.
+
+This layered approach keeps the front‑end and back‑end loosely coupled while leveraging Supabase as a hosted database and authentication service.
+

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -1,0 +1,32 @@
+# Project Setup
+
+This document explains how to configure a local development environment for the Budgeting App.
+
+## Requirements
+
+- Node.js 18 or higher
+- npm or another compatible package manager
+- Supabase CLI for running the local database
+
+## Installation
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Copy the example environment file and fill in your credentials:
+   ```bash
+   cp .env.example .env
+   ```
+   Update `.env` with your Supabase and Plaid keys.
+3. Start the Supabase stack locally:
+   ```bash
+   supabase start
+   ```
+4. Launch the development server:
+   ```bash
+   npm run dev
+   ```
+
+The application will be available at <http://localhost:3000>.
+


### PR DESCRIPTION
## Summary
- rewrite the README with feature overview and setup instructions
- add a CONTRIBUTING guide and a Code of Conduct
- document project setup and architecture under `docs/`

## Testing
- `npm run lint` *(fails: cookieStore assigned a value but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6848b7765c4c832a9fad8c9f635ea379