### PR TITLE
Add deferral feature for fixed items

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -78,3 +78,9 @@ export interface PlaidTransaction {
   iso_currency_code: string | null;
   pending: boolean;
 }
+
+export type Deferral = {
+  id: string;
+  paycheck_id: string;
+  fixed_item_id: string;
+};

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -447,6 +447,42 @@ export type Database = {
           }
         ];
       };
+      deferrals: {
+        Row: {
+          created_at: string | null;
+          id: string;
+          fixed_item_id: string;
+          paycheck_id: string;
+        };
+        Insert: {
+          created_at?: string | null;
+          id?: string;
+          fixed_item_id: string;
+          paycheck_id: string;
+        };
+        Update: {
+          created_at?: string | null;
+          id?: string;
+          fixed_item_id?: string;
+          paycheck_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "deferrals_fixed_item_id_fkey";
+            columns: ["fixed_item_id"];
+            isOneToOne: false;
+            referencedRelation: "fixed_items";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "deferrals_paycheck_id_fkey";
+            columns: ["paycheck_id"];
+            isOneToOne: false;
+            referencedRelation: "paychecks";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       vaults: {
         Row: {
           created_at: string | null;


### PR DESCRIPTION
## Summary
- add `Deferral` type and Supabase table definition
- load deferrals when planning paychecks
- allow deferring fixed items to next paycheck via UI buttons
- exclude deferred items from totals while showing carried-over items

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6848d6fa1994832a94fddb9f3d9d69d1