### PR TITLE
Fix input zoom on iOS

### DIFF
--- a/components/ui/date.tsx
+++ b/components/ui/date.tsx
@@ -9,7 +9,7 @@ const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
       <input
         type="date"
         className={cn(
-          "flex h-10 w-full rounded-md border border-border bg-card px-3 py-2 text-sm",
+          "flex h-10 w-full rounded-md border border-border bg-card px-3 py-2 text-base",
           "placeholder:text-muted-foreground text-foreground ring-offset-background",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
           "disabled:cursor-not-allowed disabled:opacity-50",

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -9,7 +9,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-border bg-card text-foreground px-3 py-2 text-sm",
+          "flex h-10 w-full rounded-md border border-border bg-card text-foreground px-3 py-2 text-base",
           "placeholder:text-muted-foreground ring-offset-background",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
           "disabled:cursor-not-allowed disabled:opacity-50",

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -8,7 +8,7 @@ const Select = React.forwardRef<
   return (
     <select
       className={cn(
-        "flex h-10 w-full rounded-md border border-border bg-card text-foreground px-3 py-2 text-sm",
+        "flex h-10 w-full rounded-md border border-border bg-card text-foreground px-3 py-2 text-base",
         "ring-offset-background placeholder:text-muted-foreground",
         "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
         "disabled:cursor-not-allowed disabled:opacity-50",

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -8,7 +8,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex w-full rounded-md border border-border bg-card text-foreground px-3 py-2 text-sm",
+        "flex w-full rounded-md border border-border bg-card text-foreground px-3 py-2 text-base",
         "ring-offset-background placeholder:text-muted-foreground",
         "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
         "disabled:cursor-not-allowed disabled:opacity-50",


### PR DESCRIPTION
## Summary
- bump font size for Input, DateInput, Select and Textarea components to `text-base`

## Testing
- `npm run lint` *(fails: cookieStore is assigned a value but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6849ef454f24832ab3842f1b07821900