### PR TITLE
Improve auth redirect timing

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -23,7 +23,24 @@ export async function middleware(req: NextRequest) {
     }
   );
 
-  await supabase.auth.getSession();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  const { pathname } = req.nextUrl;
+  const isAuthRoute = pathname.startsWith("/login") || pathname.startsWith("/auth");
+
+  if (!session && !isAuthRoute) {
+    const redirectUrl = req.nextUrl.clone();
+    redirectUrl.pathname = "/login";
+    redirectUrl.searchParams.set("next", pathname);
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  if (session && pathname === "/login") {
+    return NextResponse.redirect(new URL("/dashboard", req.url));
+  }
+
   return res;
 }
 


### PR DESCRIPTION
## Summary
- immediately redirect to `/login` from `middleware.ts` when not authed
- avoid flicker by redirecting authenticated users away from `/login`

## Testing
- `npm run lint` *(fails: cookieStore unused and other existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a51bc0ac8832a891c7b1682e62bf8