### PR TITLE
Switch to ApprovedBudget after confirmation

### DIFF
--- a/app/paycheck/components/BudgetPlanningForm.tsx
+++ b/app/paycheck/components/BudgetPlanningForm.tsx
@@ -14,6 +14,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 interface BudgetPlanningFormProps {
   paycheckId: string;
+  onApproved?: () => void;
 }
 
 type PaycheckRecord = {
@@ -56,6 +57,7 @@ function getDueDatesForItem(
 
 export default function BudgetPlanningForm({
   paycheckId,
+  onApproved,
 }: BudgetPlanningFormProps) {
   const [record, setRecord] = useState<PaycheckRecord | null>(null);
   const [paycheckDates, setPaycheckDates] = useState<PaycheckDate[]>([]);
@@ -361,6 +363,10 @@ export default function BudgetPlanningForm({
 
   const handleApproveBudget = async () => {
     if (isApproving || !start) return;
+    const confirmed = window.confirm(
+      "Are you sure you want to approve this budget?"
+    );
+    if (!confirmed) return;
     setIsApproving(true);
 
     const { data: user } = await supabase.auth.getUser();
@@ -490,6 +496,9 @@ export default function BudgetPlanningForm({
     if (updated.data) setRecord(updated.data as PaycheckRecord);
 
     setIsApproving(false);
+    if (updated.data) {
+      onApproved?.();
+    }
   };
 
   if (!record || !selectedDate) {

--- a/app/paycheck/page.tsx
+++ b/app/paycheck/page.tsx
@@ -108,7 +108,14 @@ export default function PaycheckPage() {
         </section>
 
         {paycheck && !paycheck.approved && (
-          <BudgetPlanningForm paycheckId={paycheck.id} />
+          <BudgetPlanningForm
+            paycheckId={paycheck.id}
+            onApproved={() =>
+              setPaycheck((p) =>
+                p ? { ...p, approved: true } : p
+              )
+            }
+          />
         )}
         {paycheck && paycheck.approved && (
           <ApprovedBudgetView paycheckId={paycheck.id} />


### PR DESCRIPTION
## Summary
- add optional `onApproved` callback to `BudgetPlanningForm`
- ask the user for confirmation before approving the budget
- call the callback when the budget is approved
- update the paycheck page to update state when a budget is approved

## Testing
- `npm run lint` *(fails: errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_684c958c6154832a877561fa85fb738a